### PR TITLE
Display discussions list as table

### DIFF
--- a/assets/scripts/templates/discussions-listing.handlebars
+++ b/assets/scripts/templates/discussions-listing.handlebars
@@ -1,10 +1,16 @@
 {{#each discussions as |discussion|}}
   {{log discussion}}
 
-  <li data-id="{{discussion.id}}">
-    <strong>{{discussion.title}}</strong>
-    {{#if discussion.editable}}
-      <button class="update-topic" data-toggle="modal" data-target="#udpateTopicModal" data-id="{{discussion.id}}" type="button">Modify</button>
-    {{/if}}
-  </li>
+  {{#if discussion.editable}}
+    <tr data-id="{{discussion.id}}" class="table-primary">
+      <td><button class="update-topic" data-toggle="modal" data-target="#udpateTopicModal" data-id="{{discussion.id}}" type="button">Modify</button></td>
+      <td>{{discussion.title}}</td>
+    </tr>
+  {{else}}
+    <tr data-id="{{discussion.id}}" class="table-secondary">
+      <td></td>
+      <td>{{discussion.title}}</td>
+    </tr>
+  {{/if}}
+
 {{/each}}

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -26,6 +26,7 @@ button.edit, button.remove {
 
 button.update-topic {
   font-size: 12px;
+  margin: 5px;
 }
 
 nav button {
@@ -58,6 +59,13 @@ nav {
   background-color: $pure-black;
   color: $pure-white;
   margin: 0;
+}
+
+.table {
+  text-align: left;
+  max-width: 90%;
+  margin: auto;
+  border: 2px black solid;
 }
 
 .auth-alert-main,

--- a/index.html
+++ b/index.html
@@ -30,9 +30,11 @@
             <h1>Proposed Sessions</h1>
             <button class="list-discussions">Refresh List</button>
             <button class="propose-topic hidden" data-toggle="modal" data-target="#proposeTopicModal" type="button">Propose a Topic</button>
-            <div class="discussion-list">
-              <!-- content to be added via Handlebars -->
-            </div>
+            <table class="table table-striped">
+              <tbody class="discussion-list">
+                <!-- content to be added via Handlebars -->
+              </tbody >
+            </table>
           </section>
         </main>
         <footer class="row">


### PR DESCRIPTION
- Set up `#discussion-list` table in `index.html`, removing old
`#discussion-list` div
- Update `discussions-listing.handlebars` to create table rows instead
of list items
- Update table styling in `index.scss`